### PR TITLE
fix: NS-5147: Remove the unsupported jenkins.setAgentProtocols

### DIFF
--- a/pkg/configuration/base/resources/base_configuration_configmap.go
+++ b/pkg/configuration/base/resources/base_configuration_configmap.go
@@ -72,14 +72,7 @@ def jenkins = Jenkins.instance
 
 println("Disabling insecure Jenkins features...")
 
-println("Disabling insecure protocols...")
-println("Old protocols: [" + jenkins.getAgentProtocols().join(", ") + "]")
-HashSet<String> newProtocols = new HashSet<>(jenkins.getAgentProtocols())
-newProtocols.removeAll(Arrays.asList("JNLP3-connect", "JNLP2-connect", "JNLP-connect", "CLI-connect"))
-println("New protocols: [" + newProtocols.join(", ") + "]")
-jenkins.setAgentProtocols(newProtocols)
 
-println("Disabling CLI access of /cli URL...")
 def remove = { list ->
     list.each { item ->
         if (item.getClass().name.contains("CLIAction")) {


### PR DESCRIPTION
Removed code for disabling insecure protocols and CLI access.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Removes the unsupported `jenkins.setAgentProtocols(...)` call from the operator-generated base configuration Groovy script.

Jenkins 2.483+ no longer allows `Jenkins.agentProtocols` to be configured. With Jenkins 2.555.2, the operator’s current base configuration script logs:

```text
java.lang.IllegalStateException: Jenkins.agentProtocols no longer configurable
```
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [ ] Includes docs (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._
